### PR TITLE
Genericize the ChatGPT String Modifier Component

### DIFF
--- a/ofrak_ai/ofrak_ai/chatgpt_string_modifier.py
+++ b/ofrak_ai/ofrak_ai/chatgpt_string_modifier.py
@@ -61,6 +61,9 @@ class ChatGPTStringModifierConfig(ChatGPTConfig):
     :param voice_type: the type of voice to ask ChatGPT to rewrite strings in
     :param voice_config: the words to be passed to ChatGPT in the requests to modify the strings
         using the requested voice; voice_config is ignored if the value of voice_type is not CUSTOM
+
+    :raises ValueError: if voice_type is set to CUSTOM without supplying a valid VoiceConfig or if
+        voice_type is an invalid value
     """
 
     min_length: int = 50

--- a/ofrak_ai/ofrak_ai_test/test_chatgpt_string_modifier.py
+++ b/ofrak_ai/ofrak_ai_test/test_chatgpt_string_modifier.py
@@ -7,9 +7,10 @@ from ofrak.ofrak_context import OFRAKContext
 from ofrak.resource import Resource
 from ofrak.service.resource_service_i import ResourceFilter
 from ofrak.core.strings import AsciiString
-from ofrak_ai.sassy_string_modifier import (
-    SassyStringModifier,
-    SassyStringModifierConfig,
+from ofrak_ai.chatgpt_string_modifier import (
+    ChatGPTStringModifier,
+    ChatGPTStringModifierConfig,
+    VoiceType,
 )
 
 SOURCE_DIR = os.path.join(os.path.dirname(__file__), "assets/")
@@ -49,7 +50,12 @@ async def test_sassy_string_modifier(resource: Resource, elf_file):
 
     tasks = list()
     for string in child_strings:
-        tasks.append(string.run(SassyStringModifier, SassyStringModifierConfig()))
+        tasks.append(
+            string.run(
+                ChatGPTStringModifier,
+                ChatGPTStringModifierConfig(voice_type=VoiceType.SASSY),
+            )
+        )
     await asyncio.gather(*tasks)
 
     sassy_path = os.path.join(os.path.dirname(elf_file), OUTPUT_FILE_NAME)

--- a/ofrak_ai/setup.py
+++ b/ofrak_ai/setup.py
@@ -15,7 +15,7 @@ class egg_info_ex(egg_info):
         egg_info.run(self)
 
 
-with open("README.md") as f:
+with open("../README.md") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Genericize the ChatGPT String Modifier so that it is capable of using additional built-in + custom voices for modifying strings.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Rename files and classes from SassyStringModifier -> ChatGPTStringModifier, add VoiceType and VoiceConfig for supplying built-in and custom voices, add enforcement of voice as `__post_init__` to the `ChatGPTStringModifierConfig` class.

**Anyone you think should look at this, specifically?**
@whyitfor @EdwardLarson 
